### PR TITLE
Feat/httpsrollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Svelte Starter Template with;
 - Less Support
 - Bulma
 - Svelte-Router
-- Support for Local HTTPS support
+- Support for Local HTTPS
 
 Contains `Global Styles`, and `Variables` for styling.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Svelte Starter Template with;
 - Less Support
 - Bulma
 - Svelte-Router
+- Support for Local HTTPS support
 
 Contains `Global Styles`, and `Variables` for styling.
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "start": "sirv public -s"
+    "start": "sirv public -s",
+    "__start__HTTPS__" : "sirv public -s --http2 --key ./certs/server.key --cert ./certs/server.crt"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^16.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -81,6 +81,14 @@ export default {
 		// Watch the `public` directory and refresh the
 		// browser on changes when not in production
 		!production && livereload('public'),
+		// Uncomment to get HTTPS support you'll need to create SSL Certs
+		// !production && livereload({
+		// 	watch : 'public', 
+		// 	https: { 
+		// 		key : fs.readFileSync('./certs/server.key'), 
+		// 		cert : fs.readFileSync('./certs/server.crt')
+		// 	}
+		// })
 
 		// If we're building for production (npm run build
 		// instead of npm run dev), minify


### PR DESCRIPTION
Adding options, commented out, to allow for HTTPS support for local development.